### PR TITLE
Fix screen reader's header

### DIFF
--- a/_source/index.html
+++ b/_source/index.html
@@ -25,7 +25,7 @@ layout: page
 
 <section class="home-block --connector animate --delay-s" data-aos="--fade-in-pop">
   <h2 class="space --bottom-flush">
-    <span class="display --sr-only">Stimulus</span>
+    <span class="display --sr-only">Turbo</span>
     <img class="home-block__logo" width="200" height="45" src="/assets/logos/turbo.svg" alt="">
   </h2>
   <p class="space --top-flush">The heart of Hotwire is Turbo. A set of complementary techniques for speeding up page changes and form submissions, dividing complex pages into components, and stream partial page updates over WebSocket. All without writing any JavaScript at all. And designed from the start to integrate perfectly with native hybrid applications for iOS and Android.</p>


### PR DESCRIPTION
The `--sr-only` header for the Turbo section is incorrect. 
This PR fixes it.
Stimulus -> Turbo