### PR TITLE
Mention Rails on the homepage

### DIFF
--- a/_source/index.html
+++ b/_source/index.html
@@ -9,6 +9,7 @@ layout: page
     {% include svg/spark.svg %}
   </div>
   <p><strong class="text --size-l">Hotwire is an alternative approach to building modern web applications without using much JavaScript by sending HTML instead of JSON over the wire.</strong> This makes for fast first-load pages, keeps template rendering on the server, and allows for a simpler, more productive development experience in any programming language, without sacrificing any of the speed or responsiveness associated with a traditional single-page application.</p>
+  <p>Hotwire is the default front-end framework for <a href="https://rubyonrails.org/" target="_blank">Rails</a>, but it works with any server-side app framework.</p>
   <div class="video" id="screencast">
     <video poster="/assets/videos/hotwire-screencast-poster.jpg" width="1920" height="1080" controls playsinline>
       <source src="https://d1d6azhz7lc2s3.cloudfront.net/hotwire-screencast.mp4" type="video/mp4">


### PR DESCRIPTION
[This tweet](https://twitter.com/bradgessler/status/1630655618460811264) is good feedback. While Hotwire does not depend on Rails, it does come coupled with Rails for the majority of users. So it is probably a good idea to acknowledge this on the homepage so users don't wonder if they are lost.

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/509837/222294208-01af235b-d270-4745-a19b-a5d93fa58dc0.png">
